### PR TITLE
Support DW_FORM_string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,8 +293,8 @@ impl<'a> Producers<'a> {
                         gimli::AttributeValue::DebugStrRef(offset) => {
                             return Ok(Some(self.debug_str.get_str(offset)?.to_string()?.into()));
                         }
-                        gimli::AttributeValue::String(string) => {
-                            return Ok(Some(String::from_utf8_lossy(&string).into_owned()));
+                        gimli::AttributeValue::String(ref string) => {
+                            return Ok(Some(String::from_utf8_lossy(string).into_owned()));
                         }
                         gimli::AttributeValue::Block(data) => {
                             return Ok(Some(data.to_string()?.into()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,6 +293,9 @@ impl<'a> Producers<'a> {
                         gimli::AttributeValue::DebugStrRef(offset) => {
                             return Ok(Some(self.debug_str.get_str(offset)?.to_string()?.into()));
                         }
+                        gimli::AttributeValue::String(string) => {
+                            return Ok(Some(String::from_utf8_lossy(&string).into_owned()));
+                        }
                         gimli::AttributeValue::Block(data) => {
                             return Ok(Some(data.to_string()?.into()));
                         }


### PR DESCRIPTION
Some compiler, like Digital Mars D compiler, produces `DW_AT_producer` as DW_FORM_string.

### Before

```console
$ ./target/debug/dwprod ~/dev/dlang/helloworld
GNU C11 7.5.0 -mtune=generic -march=x86-64 -g -O2 -O3 -std=gnu11 -fgnu89-inline -fmerge-all-constants -frounding-math -fstack-protector-strong -fPIC -ftls-model=initial-exec -fstack-protector-strong
```

### After

```console
$ ./target/debug/dwprod ~/dev/dlang/helloworld
Digital Mars D v2.098.1
GNU C11 7.5.0 -mtune=generic -march=x86-64 -g -O2 -O3 -std=gnu11 -fgnu89-inline -fmerge-all-constants -frounding-math -fstack-protector-strong -fPIC -ftls-model=initial-exec -fstack-protector-strong
```